### PR TITLE
fix: 修复 Star History 图表无法加载的问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@
 
 ### Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Zitann/HarmonyOS-Haps&type=Date)](https://star-history.com/#Zitann/HarmonyOS-Haps&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Zitann/HarmonyOS-Haps&type=Date)](https://star-history.dera.page/#Zitann/HarmonyOS-Haps&Date)
 
 <!-- links -->
 


### PR DESCRIPTION
Star History 图表因当前数据源受限而无法正常加载，影响仓库展示。此改动将该图表链接切换到新的可用服务地址，恢复图表的正常显示。